### PR TITLE
Added notebooks folder with readme

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,1 @@
+#This folder contains all the notebooks created during GHC 2016 Open Source Day.


### PR DESCRIPTION
I added a folder for notebooks created during GHC 2016 Open Source Day. The readme is in there because GitHub doesn't allow empty folders to be added to a repo.
